### PR TITLE
fix: Add default value for `alert_manager_definition`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `null` | no |
+| <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\nroute:\n  receiver: 'default'\nreceivers:\n  - name: 'default'\n"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_rule_group_namespaces"></a> [rule\_group\_namespaces](#input\_rule\_group\_namespaces) | A map of one or more rule group namespace definitions | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,13 @@ variable "workspace_alias" {
 variable "alert_manager_definition" {
   description = "The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html)"
   type        = string
-  default     = null
+  default     = <<EOF
+alertmanager_config: |
+  route:
+    receiver: 'default'
+  receivers:
+    - name: 'default'
+EOF
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -27,13 +27,13 @@ variable "workspace_alias" {
 variable "alert_manager_definition" {
   description = "The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html)"
   type        = string
-  default     = <<EOF
-alertmanager_config: |
-  route:
-    receiver: 'default'
-  receivers:
-    - name: 'default'
-EOF
+  default     = <<-EOF
+	    alertmanager_config: |
+	    route:
+	      receiver: 'default'
+	    receivers:
+	      - name: 'default'
+  EOF
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
This fixes and issue with the latest version of this module when no value is provided for `alert_manager_definition` and the current default value [`null`] is used:

```
Error: Missing required argument

  with module.global-zone.module.prometheus.aws_prometheus_alert_manager_definition.this[0],
  on .terraform/modules/global-zone.prometheus/main.tf line 20, in resource "aws_prometheus_alert_manager_definition" "this":
  20:   definition   = var.alert_manager_definition

The argument "definition" is required, but no definition was found.
```
This error matches the aws provider documentation and [`definition` is required](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_alert_manager_definition#definition)


A empty string value [`""`] will not work for this either and produces this error:
```
Error: error creating Prometheus Alert Manager Definition (ws-f6f96b26-b023-41ce-975f-e5c0667f6fc3): ValidationException: Malformed Alertmanager definition.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "31676246-1759-465c-94fc-3f954ae6a10d"
  },
  Message_: "Malformed Alertmanager definition."
}
```

This PR changes the module to use a very basic definition as the default value for `alert_manager_definition`


## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)