### PR TITLE
fix: Correct alert manager default definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.68.1
+    rev: v1.73.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\nroute:\n  receiver: 'default'\nreceivers:\n  - name: 'default'\n"` | no |
+| <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_rule_group_namespaces"></a> [rule\_group\_namespaces](#input\_rule\_group\_namespaces) | A map of one or more rule group namespace definitions | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -34,6 +34,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_default"></a> [default](#module\_default) | ../.. | n/a |
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../.. | n/a |
 | <a name="module_prometheus"></a> [prometheus](#module\_prometheus) | ../.. | n/a |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,12 +11,6 @@ locals {
 # Prometheus Module
 ################################################################################
 
-module "disabled" {
-  source = "../.."
-
-  create = false
-}
-
 module "prometheus" {
   source = "../.."
 
@@ -52,4 +46,16 @@ module "prometheus" {
       EOT
     }
   }
+}
+
+module "disabled" {
+  source = "../.."
+
+  create = false
+}
+
+module "default" {
+  source = "../.."
+
+  workspace_alias = "${local.name}-default"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,13 +27,13 @@ variable "workspace_alias" {
 variable "alert_manager_definition" {
   description = "The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html)"
   type        = string
-  default     = <<-EOF
-	    alertmanager_config: |
-	    route:
-	      receiver: 'default'
-	    receivers:
-	      - name: 'default'
-  EOF
+  default     = <<-EOT
+    alertmanager_config: |
+      route:
+        receiver: 'default'
+      receivers:
+        - name: 'default'
+  EOT
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Correcting alert manager default definition - indentation
- update precommit version following `pre-commit autoupdate`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- post https://github.com/terraform-aws-modules/terraform-aws-managed-service-prometheus/pull/3 , seeing same failures "Malformed Alertmanager definition" , using version `2.1.2`

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
