### PR TITLE
feat: Add support for using an existing/external workspace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.73.0
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
+| <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_rule_group_namespaces"></a> [rule\_group\_namespaces](#input\_rule\_group\_namespaces) | A map of one or more rule group namespace definitions | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_workspace_alias"></a> [workspace\_alias](#input\_workspace\_alias) | The alias of the prometheus workspace. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html) | `string` | `null` | no |
+| <a name="input_workspace_id"></a> [workspace\_id](#input\_workspace\_id) | The ID of an existing workspace to use when `create_workspace` is `false` | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,13 @@
+locals {
+  workspace_id = var.create_workspace ? aws_prometheus_workspace.this[0].id : var.workspace_id
+}
+
 ################################################################################
 # Workspace
 ################################################################################
 
 resource "aws_prometheus_workspace" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.create_workspace ? 1 : 0
 
   alias = var.workspace_alias
   tags  = var.tags
@@ -16,7 +20,7 @@ resource "aws_prometheus_workspace" "this" {
 resource "aws_prometheus_alert_manager_definition" "this" {
   count = var.create ? 1 : 0
 
-  workspace_id = aws_prometheus_workspace.this[0].id
+  workspace_id = local.workspace_id
   definition   = var.alert_manager_definition
 }
 
@@ -28,6 +32,6 @@ resource "aws_prometheus_rule_group_namespace" "this" {
   for_each = var.create ? var.rule_group_namespaces : {}
 
   name         = each.value.name
-  workspace_id = aws_prometheus_workspace.this[0].id
+  workspace_id = local.workspace_id
   data         = each.value.data
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,18 @@ variable "tags" {
 # Workspace
 ################################################################################
 
+variable "create_workspace" {
+  description = "Determines whether a workspace will be created or to use an existing workspace"
+  type        = bool
+  default     = true
+}
+
+variable "workspace_id" {
+  description = "The ID of an existing workspace to use when `create_workspace` is `false`"
+  type        = string
+  default     = ""
+}
+
 variable "workspace_alias" {
   description = "The alias of the prometheus workspace. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html)"
   type        = string


### PR DESCRIPTION
## Description
- Add support for using an existing/external workspace

## Motivation and Context
- Support scenarios where an existing/external workspace exists

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->