### PR TITLE
fix: Fix dependencies and implementation of the logging configuration support feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.35 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n"` | no |
-| <a name="input_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#input\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch log group which will be used for the monitoring of the prometheus workspace. | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
-| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Whether to enable Cloudwatch logging for the prometheus workspace or not. If this is set to true, you need to set the cloudwatch\_log\_group\_arn attribute. | `bool` | `false` | no |
+| <a name="input_logging_configuration"></a> [logging\_configuration](#input\_logging\_configuration) | The logging configuration of the prometheus workspace. | `map(string)` | `{}` | no |
 | <a name="input_rule_group_namespaces"></a> [rule\_group\_namespaces](#input\_rule\_group\_namespaces) | A map of one or more rule group namespace definitions | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_workspace_alias"></a> [workspace\_alias](#input\_workspace\_alias) | The alias of the prometheus workspace. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html) | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n"` | no |
+| <a name="input_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#input\_cloudwatch\_log\_group\_arn) | The ARN of the Cloudwatch log group which will be used for the monitoring of the prometheus workspace. | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
+| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Whether to enable Cloudwatch logging for the prometheus workspace or not. If this is set to true, you need to set the cloudwatch\_log\_group\_arn attribute. | `bool` | `false` | no |
 | <a name="input_rule_group_namespaces"></a> [rule\_group\_namespaces](#input\_rule\_group\_namespaces) | A map of one or more rule group namespace definitions | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_workspace_alias"></a> [workspace\_alias](#input\_workspace\_alias) | The alias of the prometheus workspace. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html) | `string` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.35 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,7 +28,9 @@ Note that this example may create resources which will incur monetary charges on
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1 |
 
 ## Modules
 
@@ -40,7 +42,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 
 ## Inputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,9 +14,10 @@ locals {
 module "prometheus" {
   source = "../.."
 
-  workspace_alias          = local.name
-  enable_logging           = true
-  cloudwatch_log_group_arn = aws_cloudwatch_log_group.this.arn
+  workspace_alias = local.name
+  logging_configuration = {
+    log_group_arn = aws_cloudwatch_log_group.this.arn
+  }
 
   alert_manager_definition = <<-EOT
   alertmanager_config: |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,7 +14,9 @@ locals {
 module "prometheus" {
   source = "../.."
 
-  workspace_alias = local.name
+  workspace_alias          = local.name
+  enable_logging           = true
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.this.arn
 
   alert_manager_definition = <<-EOT
   alertmanager_config: |
@@ -58,4 +60,11 @@ module "default" {
   source = "../.."
 
   workspace_alias = "${local.name}-default"
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+resource "aws_cloudwatch_log_group" "this" {
+  name = "example-aws-managed-service-prometheus-complete"
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1"
+      version = ">= 4.35"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  workspace_id = var.create && var.create_workspace ? aws_prometheus_workspace.this[0].id : var.workspace_id
+}
+
 ################################################################################
 # Workspace
 ################################################################################
@@ -8,9 +12,10 @@ resource "aws_prometheus_workspace" "this" {
   alias = var.workspace_alias
 
   dynamic "logging_configuration" {
-    for_each = var.enable_logging ? [0] : []
+    for_each = length(var.logging_configuration) > 0 ? [var.logging_configuration] : []
+
     content {
-      log_group_arn = "${var.cloudwatch_log_group_arn}:*"
+      log_group_arn = logging_configuration.value.log_group_arn
     }
   }
 
@@ -24,7 +29,7 @@ resource "aws_prometheus_workspace" "this" {
 resource "aws_prometheus_alert_manager_definition" "this" {
   count = var.create ? 1 : 0
 
-  workspace_id = var.create_workspace ? aws_prometheus_workspace.this[0].id : var.workspace_id
+  workspace_id = local.workspace_id
   definition   = var.alert_manager_definition
 }
 
@@ -36,6 +41,6 @@ resource "aws_prometheus_rule_group_namespace" "this" {
   for_each = var.create ? var.rule_group_namespaces : {}
 
   name         = each.value.name
-  workspace_id = var.create_workspace ? aws_prometheus_workspace.this[0].id : var.workspace_id
+  workspace_id = local.workspace_id
   data         = each.value.data
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,18 @@ variable "workspace_alias" {
   default     = null
 }
 
+variable "enable_logging" {
+  description = "Whether to enable Cloudwatch logging for the prometheus workspace or not. If this is set to true, you need to set the cloudwatch_log_group_arn attribute."
+  type        = bool
+  default     = false
+}
+
+variable "cloudwatch_log_group_arn" {
+  description = "The ARN of the Cloudwatch log group which will be used for the monitoring of the prometheus workspace."
+  type        = string
+  default     = null
+}
+
 ################################################################################
 # Alert Manager Definition
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -32,16 +32,10 @@ variable "workspace_alias" {
   default     = null
 }
 
-variable "enable_logging" {
-  description = "Whether to enable Cloudwatch logging for the prometheus workspace or not. If this is set to true, you need to set the cloudwatch_log_group_arn attribute."
-  type        = bool
-  default     = false
-}
-
-variable "cloudwatch_log_group_arn" {
-  description = "The ARN of the Cloudwatch log group which will be used for the monitoring of the prometheus workspace."
-  type        = string
-  default     = null
+variable "logging_configuration" {
+  description = "The logging configuration of the prometheus workspace."
+  type        = map(string)
+  default     = {}
 }
 
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1"
+      version = ">= 4.35"
     }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR addresses the following:
#7 : using the locals to reference the workspace id has as a consequence that terraform does not know the interdependencies between the workspace, the alert manager config and the rule namespace group.
#8 : this feature will allow to add the support of cloudwatch logging to the prometheus workspace.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR fixes the example and adds the support for the prometheus worksapce logging configuration.
<!--- If it fixes an open issue, please link to the issue here. -->
see issues fixed above.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
