### PR TITLE
chore: Update `complete/` example to add trailing `:*` to the `log_group_arn` argument

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -16,7 +16,7 @@ module "prometheus" {
 
   workspace_alias = local.name
   logging_configuration = {
-    log_group_arn = aws_cloudwatch_log_group.this.arn
+    log_group_arn = "${aws_cloudwatch_log_group.this.arn}:*"
   }
 
   alert_manager_definition = <<-EOT


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
append of ":*" in the arn of the cloudwatch log group to match the provider requirements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing the complete example.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
