### PR TITLE
feat: Add the capability to disable alert manager creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_manager_definition"></a> [alert\_manager\_definition](#input\_alert\_manager\_definition) | The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html) | `string` | `"alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether a resources will be created | `bool` | `true` | no |
+| <a name="input_create_alert_manager"></a> [create\_alert\_manager](#input\_create\_alert\_manager) | Controls whether an Alert Manager definition is created along with the AMP workspace | `bool` | `true` | no |
 | <a name="input_create_workspace"></a> [create\_workspace](#input\_create\_workspace) | Determines whether a workspace will be created or to use an existing workspace | `bool` | `true` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS Key to for encryption at rest | `string` | `null` | no |
 | <a name="input_logging_configuration"></a> [logging\_configuration](#input\_logging\_configuration) | The logging configuration of the prometheus workspace. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ module "prometheus" {
 
   workspace_alias = "example"
 
+  create_alert_manager     = true
   alert_manager_definition = <<-EOT
   alertmanager_config: |
     route:

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,6 +19,7 @@ module "prometheus" {
     log_group_arn = "${aws_cloudwatch_log_group.this.arn}:*"
   }
 
+  create_alert_manager     = true
   alert_manager_definition = <<-EOT
   alertmanager_config: |
     route:

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_prometheus_workspace" "this" {
 ################################################################################
 
 resource "aws_prometheus_alert_manager_definition" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.create_alert_manager ? 1 : 0
 
   workspace_id = local.workspace_id
   definition   = var.alert_manager_definition

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,12 @@ variable "kms_key_arn" {
 # Alert Manager Definition
 ################################################################################
 
+variable "create_alert_manager" {
+  description = "Controls whether an Alert Manager definition is created along with the AMP workspace"
+  type        = bool
+  default     = true
+}
+
 variable "alert_manager_definition" {
   description = "The alert manager definition that you want to be applied. See more in the [AWS Docs](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html)"
   type        = string


### PR DESCRIPTION
## Description
This PR adds a new `create_alert_manager` variable to the AWS Managed Service for Prometheus (AMP) Terraform module, allowing users to conditionally disable Alert Manager creation. The variable defaults to true to maintain backward compatibility.

## Motivation and Context
- Resolves #19

- Currently, the module always provisions an Alert Manager along with the AMP workspace
- Users with existing external alerting systems or those who don't want Alert Manager are forced to create unnecessary resources
- This adds extra overhead and confusion for users who don't need Alert Manager functionality

## Breaking Changes
None. This change is fully backward compatible:

- The create_alert_manager variable defaults to true, preserving existing behavior
- All existing configurations will continue to work without modification
- No existing resources or configurations are affected

## How Has This Been Tested?

- [x] I have updated at least one of the examples/* to demonstrate and validate my change(s)
  - Updated examples/complete/main.tf to include create_alert_manager = true in the main example
- [x] I have tested and validated these changes using one or more of the provided examples/* projects
  - Verified that the module works correctly with both create_alert_manager = true (default) and create_alert_manager = false
  - Confirmed that Alert Manager resources are only created when both create and create_alert_manager are true
  - Tested that the module maintains backward compatibility with existing configurations
- [x] I have executed pre-commit run -a on my pull request
  -  All pre-commit hooks passed successfully
  - Documentation was auto-generated using terraform-docs
  - Code formatting and validation completed without issues
